### PR TITLE
Declare requests as an install dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/requeriments.txt
+++ b/requeriments.txt
@@ -1,2 +1,3 @@
 habanero
 bibtexparser
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+habanero
+bibtexparser
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+import setuptools
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="orcid2markdown",
+    version="0.0.1a",
+    author="Pedro B. C.",
+    author_email="pedro@pedrobcst.com",
+    description="A simple package to parse an ORCID works entry into a Markdown format for static website generators",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/pedrobcst/orcid2markdown",
+    project_urls={
+        "Bug Tracker": "https://github.com/pedrobcst/orcid2markdown/issues",
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    package_dir={"": "src"},
+    packages=setuptools.find_packages(where="src"),
+    python_requires=">=3.7",
+    install_requires=[
+        "habanero",
+        "bibtexparser",
+        "requests",
+    ],
+)


### PR DESCRIPTION
Fixes #2.

The published package imports `requests` at module import time, but the package metadata only installs `habanero` and `bibtexparser`. With current `habanero`, `requests` is no longer pulled transitively, so a clean install fails before users can instantiate `ORCID2Markdown`.

Reproduced with:

```powershell
python -m venv D:\Temp\orcid2markdown-pip-repro-codex
D:\Temp\orcid2markdown-pip-repro-codex\Scripts\python.exe -m pip install orcid2markdown
D:\Temp\orcid2markdown-pip-repro-codex\Scripts\python.exe -c "from orcid2markdown import ORCID2Markdown"
```

Before this change:

```text
ModuleNotFoundError: No module named 'requests'
```

This PR adds the packaging files that are already present in the PyPI sdist, declares `requests` in `install_requires`, and also updates/adds requirements files for source users.

Verified from this branch with a clean venv:

```powershell
python -m pip install D:\Temp\orcid2markdown-fix-verify-codex\ORCID2Markdown-codex-declare-requests-dependency-20260608
python -c "from orcid2markdown import ORCID2Markdown; print('IMPORT_OK', ORCID2Markdown.__name__)"
```

Result:

```text
IMPORT_OK ORCID2Markdown
```